### PR TITLE
Added some Windows thumbnail cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,9 @@ yarn-error.log
 
 # Local vscode config
 .vscode
+
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db


### PR DESCRIPTION
added some Windows thumbnail cache files to gitignore. These files include

- Thumbs.db

- Thumbs.db:encryptable

- ehthumbs.db

- ehthumbs_vista.db